### PR TITLE
feat: 监视面板显示运行中任务列表并支持取消 (#41)

### DIFF
--- a/backend/src/taskmanager.rs
+++ b/backend/src/taskmanager.rs
@@ -542,15 +542,16 @@ impl TaskManager for TaskManagerImpl {
         
                                                             //尝试下单
                                                             loop {
+                                                               if cancel_flag.load(Ordering::Relaxed) { log::info!("任务已取消"); return; }
                                                                let (success, retry_limit) = handle_grab_ticket(
-                                                                cookie_manager.clone(), 
+                                                                cookie_manager.clone(),
                                                                 cpdd.clone(),
-                                                                  &project_id, 
-                                                                  &token, 
+                                                                  &project_id,
+                                                                  &token,
                                                                   &ptoken,
                                                                   is_hot.clone(),
-                                                                  &task_id, 
-                                                                  uid, 
+                                                                  &task_id,
+                                                                  uid,
                                                                   &result_tx,
                                                                   &grab_ticket_req,
                                                                   &buyer_info
@@ -585,6 +586,7 @@ impl TaskManager for TaskManagerImpl {
                                                             //获取token失败！分析原因
                                                             if risk_param.code == -401 || risk_param.code == 401 {
                                                                 //需要处理验证码
+                                                                if cancel_flag.load(Ordering::Relaxed) { log::info!("任务已取消"); return; }
                                                                 log::warn!("需要验证码，开始处理验证码...");
                                                                 match handle_risk_verification(
                                                                     cookie_manager.clone(), 
@@ -678,15 +680,16 @@ impl TaskManager for TaskManagerImpl {
         
                                                             //尝试下单
                                                             loop {
+                                                                if cancel_flag.load(Ordering::Relaxed) { log::info!("任务已取消"); return; }
                                                                 let (success, retry_limit) = handle_grab_ticket(
-                                                                 cookie_manager.clone(), 
+                                                                 cookie_manager.clone(),
                                                                  cpdd.clone(),
-                                                                   &project_id, 
-                                                                   &token, 
+                                                                   &project_id,
+                                                                   &token,
                                                                    &ptoken,
                                                                    is_hot.clone(),
-                                                                   &task_id, 
-                                                                   uid, 
+                                                                   &task_id,
+                                                                   uid,
                                                                    &result_tx,
                                                                    &grab_ticket_req,
                                                                    &buyer_info
@@ -722,6 +725,7 @@ impl TaskManager for TaskManagerImpl {
                                                             //获取token失败！分析原因
                                                             if risk_param.code == -401 || risk_param.code == 401 {
                                                                 //需要处理验证码
+                                                                if cancel_flag.load(Ordering::Relaxed) { log::info!("任务已取消"); return; }
                                                                 log::warn!("需要验证码，开始处理验证码...");
                                                                 match handle_risk_verification(
                                                                     cookie_manager.clone(), 
@@ -882,15 +886,16 @@ impl TaskManager for TaskManagerImpl {
                                                                     const MAX_CONFIRM_RETRY: i8 = 4;
                                                             
                                                                     loop {
+                                                                        if cancel_flag.load(Ordering::Relaxed) { log::info!("任务已取消"); return; }
                                                                         let (success, retry_limit) = handle_grab_ticket(
-                                                                         cookie_manager.clone(), 
+                                                                         cookie_manager.clone(),
                                                                          cpdd.clone(),
-                                                                           &project_id, 
-                                                                           &token, 
+                                                                           &project_id,
+                                                                           &token,
                                                                            &ptoken,
                                                                            is_hot.clone(),
-                                                                           &task_id, 
-                                                                           uid, 
+                                                                           &task_id,
+                                                                           uid,
                                                                            &result_tx,
                                                                            &local_grab_request,
                                                                            &buyer_info
@@ -918,6 +923,7 @@ impl TaskManager for TaskManagerImpl {
                                                             //获取token失败！分析原因
                                                             if risk_param.code == -401 || risk_param.code == 401 {
                                                                 //需要处理验证码
+                                                                if cancel_flag.load(Ordering::Relaxed) { log::info!("任务已取消"); return; }
                                                                 log::warn!("需要验证码，开始处理验证码...");
                                                                 match handle_risk_verification(
                                                                     cookie_manager.clone(), 

--- a/backend/src/taskmanager.rs
+++ b/backend/src/taskmanager.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread;
 use std::time::{SystemTime, UNIX_EPOCH};
+use common::record_log::TASK_LABEL;
 
 use common::cookie_manager::CookieManager;
 use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -24,10 +26,33 @@ use crate::show_orderlist::get_orderlist;
 use crate::api::{*};
 
 
+struct GrabTaskEntry {
+    info_seed: RunningTaskInfo,
+    start_time: std::time::Instant,
+    cancel_flag: Arc<AtomicBool>,
+}
+
+/// RAII 守卫：任务结束时（正常返回 / return / panic unwind）都会从注册表移除该任务，
+/// 避免 panic 路径下留下永久「运行中」的僵尸条目。用 `if let Ok` 规避锁中毒再次 panic。
+struct GrabRegistryGuard {
+    registry: Arc<Mutex<HashMap<String, GrabTaskEntry>>>,
+    task_id: String,
+}
+
+impl Drop for GrabRegistryGuard {
+    fn drop(&mut self) {
+        if let Ok(mut registry) = self.registry.lock() {
+            registry.remove(&self.task_id);
+        }
+    }
+}
+
 pub struct TaskManagerImpl {
     task_sender: mpsc::Sender<TaskMessage>,
     result_receiver: mpsc::Receiver<TaskResult>,
     running_tasks: HashMap<String, Task>, // 使用 Task 枚举
+    grab_registry: Arc<Mutex<HashMap<String, GrabTaskEntry>>>,
+    seq_counter: Arc<AtomicU64>,
     runtime: Arc<Runtime>,
     _worker_thread: Option<thread::JoinHandle<()>>,
 }
@@ -47,7 +72,13 @@ impl TaskManager for TaskManagerImpl {
         // 创建tokio运行时
         let runtime = Arc::new(Runtime::new().unwrap());
         let rt = runtime.clone();
-        
+
+        let grab_registry: Arc<Mutex<HashMap<String, GrabTaskEntry>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let seq_counter: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
+        let grab_registry_worker = grab_registry.clone();
+        let seq_counter_worker = seq_counter.clone();
+
         // 启动工作线程
         let worker = thread::spawn(move || {
             rt.block_on(async {
@@ -412,7 +443,42 @@ impl TaskManager for TaskManagerImpl {
                                             cookie_manager.get_ua().clone(),
                                         )))
                                     };
+                                    // 注册到抢票任务注册表
+                                    let cancel_flag = Arc::new(AtomicBool::new(false));
+                                    let seq = seq_counter_worker.fetch_add(1, Ordering::Relaxed) + 1;
+                                    let project_name_for_entry = project_info.as_ref()
+                                        .and_then(|p| p.name.clone())
+                                        .unwrap_or_else(|| project_id.clone());
+                                    let account_name_for_entry = grab_ticket_req.biliticket.account.name.clone();
+                                    let task_label = format!("#{} {}", seq, account_name_for_entry);
+                                    {
+                                        let entry = GrabTaskEntry {
+                                            info_seed: RunningTaskInfo {
+                                                task_id: task_id.clone(),
+                                                seq,
+                                                uid,
+                                                account_name: account_name_for_entry,
+                                                project_name: project_name_for_entry,
+                                                grab_mode: mode,
+                                                status: TaskStatus::Running,
+                                                elapsed_secs: 0,
+                                            },
+                                            start_time: std::time::Instant::now(),
+                                            cancel_flag: cancel_flag.clone(),
+                                        };
+                                        if let Ok(mut reg) = grab_registry_worker.lock() {
+                                            reg.insert(task_id.clone(), entry);
+                                        }
+                                    }
+                                    let grab_registry_cleanup = grab_registry_worker.clone();
+                                    let task_id_cleanup = task_id.clone();
                                     tokio::spawn(async move{
+                                    // 守卫在 spawn 内最外层创建，任务以任何方式结束（含 panic）时都会清理注册表
+                                    let _registry_guard = GrabRegistryGuard {
+                                        registry: grab_registry_cleanup,
+                                        task_id: task_id_cleanup,
+                                    };
+                                    TASK_LABEL.scope(task_label, async move {
                                         log::debug!("开始分析抢票任务：{}",task_id);
                                        
                                         match mode {
@@ -431,15 +497,21 @@ impl TaskManager for TaskManagerImpl {
                                                 if countdown > 0.0{
                                                     log::info!("距离抢票时间还有{}秒",countdown);
                                                     loop{
+                                                        if cancel_flag.load(Ordering::Relaxed) { log::info!("任务已取消"); return; }
                                                         if countdown <= 20.0 {
                                                             break;
                                                         }
                                                         countdown = countdown - 15.0;
-                                                        tokio::time::sleep(tokio::time::Duration::from_secs(15)).await;
+                                                        // 分片 sleep，使取消在约 1 秒内生效
+                                                        for _ in 0..15 {
+                                                            if cancel_flag.load(Ordering::Relaxed) { log::info!("任务已取消"); return; }
+                                                            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                                                        }
                                                         log::info!("距离抢票时间还有{}秒",countdown);
-                                                        
+
                                                     }
                                                     loop{
+                                                        if cancel_flag.load(Ordering::Relaxed) { log::info!("任务已取消"); return; }
                                                         if countdown <= 1.3 {  //按道理来说countdown是1秒，为了保险多设置几秒
                                                             tokio::time::sleep(tokio::time::Duration::from_secs_f32(0.8)).await;
                                                             break;
@@ -459,7 +531,7 @@ impl TaskManager for TaskManagerImpl {
 
                                                 //抢票主循环
                                                 loop{
-
+                                                    if cancel_flag.load(Ordering::Relaxed) { log::info!("任务已取消"); return; }
                                                     let token_result = get_ticket_token(cookie_manager.clone(), cpdd.clone(),&project_id, &screen_id, &ticket_id, count, is_hot).await;
                                                     match token_result {
                                                         Ok((token,ptoken)) => {
@@ -586,16 +658,16 @@ impl TaskManager for TaskManagerImpl {
                                             1 => {
                                                 log::debug!("直接抢票模式");
                                                 let mut token_retry_count = 0;
-                                                const MAX_TOKEN_RETRY: i8 = 10; 
+                                                const MAX_TOKEN_RETRY: i8 = 10;
                                                 let mut confirm_order_retry_count = 0;
                                                 const MAX_CONFIRM_ORDER_RETRY: i8 = 4;
                                                 let mut order_retry_count = 0;
                                                 let mut need_retry = false;
-                                                
-                                                
+
+
                                                 //抢票主循环
                                                 loop{
-
+                                                    if cancel_flag.load(Ordering::Relaxed) { log::info!("任务已取消"); return; }
                                                     let token_result = get_ticket_token(cookie_manager.clone(), cpdd.clone(),&project_id, &screen_id, &ticket_id, count, is_hot).await;
                                                     match token_result {
                                                         Ok((token,ptoken)) => {
@@ -725,6 +797,7 @@ impl TaskManager for TaskManagerImpl {
                                                 const MAX_TOKEN_RETRY: i8 = 5;
                                                 // 外层循环，一旦抢票成功或遇到致命错误就退出
                                                 'main_loop: loop {
+                                                    if cancel_flag.load(Ordering::Relaxed) { log::info!("任务已取消"); return; }
                                                     log::debug!("project_id: {}, screen_id: {}, ticket_id: {}", project_id, screen_id, ticket_id);
                                                     
                                                     // 获取项目数据
@@ -750,6 +823,7 @@ impl TaskManager for TaskManagerImpl {
                                                     } 
                                                     local_grab_request.biliticket.id_bind = project_data.data.id_bind.unwrap_or(0);
                                                     'screen_loop: for screen_data in project_data.data.screen_list {
+                                                        if cancel_flag.load(Ordering::Relaxed) { log::info!("任务已取消"); return; }
                                                         if !screen_data.clickable {
                                                             continue; 
                                                         }
@@ -760,6 +834,7 @@ impl TaskManager for TaskManagerImpl {
                                                         
                                                         // 遍历票种
                                                         'ticket_loop: for ticket_data in screen_data.ticket_list {
+                                                            if cancel_flag.load(Ordering::Relaxed) { log::info!("任务已取消"); return; }
                                                             if !ticket_data.clickable.unwrap_or(false) {
                                                                 continue; // 跳过不可点击的票种
                                                             }
@@ -923,6 +998,8 @@ impl TaskManager for TaskManagerImpl {
                                                 log::error!("未知模式");
                                             }
                                         }
+                                    }).await; // TASK_LABEL.scope end
+                                    // 任务结束后由 _registry_guard 的 Drop 自动从注册表移除
                                     });
                                 }
                             }
@@ -940,17 +1017,19 @@ impl TaskManager for TaskManagerImpl {
             task_sender: task_tx,
             result_receiver: result_rx,
             running_tasks: HashMap::new(),
+            grab_registry,
+            seq_counter,
             runtime: runtime,
             _worker_thread: Some(worker),
         }
     }
     
-    fn submit_task(&mut self, request: TaskRequest) -> Result<String, String> {
+    fn submit_task(&mut self, mut request: TaskRequest) -> Result<String, String> {
         // 生成任务ID
         let task_id = uuid::Uuid::new_v4().to_string();
         
         // 根据请求类型创建相应的任务
-        match &request {
+        match &mut request {
             
             TaskRequest::QrCodeLoginRequest(qrcode_req) => {
                 log::info!("提交二维码登录任务 ID: {}", task_id);
@@ -1056,25 +1135,10 @@ impl TaskManager for TaskManagerImpl {
                 // 保存任务
                 self.running_tasks.insert(task_id.clone(), Task::GetBuyerInfoTask(task));
             }
-            TaskRequest::GrabTicketRequest(grab_ticket_req) => {
+            TaskRequest::GrabTicketRequest(ref mut grab_ticket_req) => {
                 log::info!("提交抢票任务 ID: {}", task_id);
-                
-               /*  // 创建抢票任务
-                let task = GrabTicketTask {
-                    task_id: task_id.clone(),
-                    project_id: grab_ticket_req.project_id.clone(),
-                    screen_id: grab_ticket_req.screen_id.clone(),
-                    ticket_id: grab_ticket_req.ticket_id.clone(),
-                    buyer_info: grab_ticket_req.buyer_info.clone(),
-                    client: grab_ticket_req.client.clone(),
-                    status: TaskStatus::Pending,
-                    start_time: Some(std::time::Instant::now()),
-                    uid: grab_ticket_req.uid.clone(),
-                    grab_mode: grab_ticket_req.grab_mode.clone(),
-                };
-                
-                // 保存任务
-                self.running_tasks.insert(task_id.clone(), Task::GrabTicketTask(task)); */
+                // 将生成的 task_id 注入请求，worker 线程将使用它作为注册表主键
+                grab_ticket_req.task_id = task_id.clone();
             }
 
         }
@@ -1099,33 +1163,46 @@ impl TaskManager for TaskManagerImpl {
     }
     
     fn cancel_task(&mut self, task_id: &str) -> Result<(), String> {
-        if !self.running_tasks.contains_key(task_id) {
-            return Err("任务不存在".to_string());
-        }
-        
-        if let Err(e) = self.task_sender.blocking_send(TaskMessage::CancelTask(task_id.to_owned())) {
-            return Err(format!("无法取消任务: {}", e));
-        }
-        
-        Ok(())
-    }
-    
-    fn get_task_status(&self, task_id: &str) -> Option<TaskStatus> {
-        if let Some(task) = self.running_tasks.get(task_id) {
-            match task {
-                
-                Task::QrCodeLoginTask(t) => Some(t.status.clone()),
-                Task::LoginSmsRequestTask(t) => Some(t.status.clone()),
-                Task::PushTask(t) => Some(t.status.clone()),
-                Task::SubmitLoginSmsRequestTask(t) => Some(t.status.clone()),
-                Task::GetAllorderRequestTask(t) => Some(t.status.clone()),
-                Task::GetTicketInfoTask(t) => Some(t.status.clone()),
-                Task::GetBuyerInfoTask(t) => Some(t.status.clone()),
-                Task::GrabTicketTask(t) => Some(t.status.clone()),
+        let registry = self
+            .grab_registry
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        match registry.get(task_id) {
+            Some(entry) => {
+                entry.cancel_flag.store(true, Ordering::Relaxed);
+                Ok(())
             }
-        } else {
-            None
+            None => Err("任务不存在".to_string()),
         }
+    }
+
+    /// 注意：当前仅反映抢票任务（grab_registry）。其它任务类型（登录/订单等）始终返回 None。
+    fn get_task_status(&self, task_id: &str) -> Option<TaskStatus> {
+        let registry = self
+            .grab_registry
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        registry.get(task_id).map(|_| TaskStatus::Running)
+    }
+
+    fn list_running_tasks(&self) -> Vec<RunningTaskInfo> {
+        let registry = self
+            .grab_registry
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let mut tasks: Vec<RunningTaskInfo> = registry
+            .values()
+            .map(|entry| {
+                let mut info = entry.info_seed.clone();
+                info.elapsed_secs = entry.start_time.elapsed().as_secs();
+                if entry.cancel_flag.load(Ordering::Relaxed) {
+                    info.status = TaskStatus::Failed("取消中".to_string());
+                }
+                info
+            })
+            .collect();
+        tasks.sort_by_key(|t| t.seq);
+        tasks
     }
     
     fn shutdown(&mut self) {

--- a/common/src/record_log.rs
+++ b/common/src/record_log.rs
@@ -5,6 +5,11 @@ use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::Path;
 
+// 每个抢票 async 任务携带的短标签，如 "#1 昵称"；非任务上下文中 try_with 返回 Err 自然无前缀
+tokio::task_local! {
+    pub static TASK_LABEL: String;
+}
+
 
 // 日志文件处理相关内容
 lazy_static::lazy_static! {
@@ -115,8 +120,11 @@ impl log::Log for CollectorLogger{
     fn log(&self,record: &Record){
         if self.enabled(record.metadata()){
             let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S:%3f");
-            let log_message = format!("[{}] {}: {}", 
-                timestamp, record.level(), record.args());
+            let label = TASK_LABEL.try_with(|l| l.clone()).ok();
+            let log_message = match label {
+                Some(l) => format!("[{}] {} [{}]: {}", timestamp, record.level(), l, record.args()),
+                None    => format!("[{}] {}: {}",      timestamp, record.level(),    record.args()),
+            };
 
                 {
                     if let Ok(mut collector) = LOG_COLLECTOR.try_lock() { // 使用 try_lock 避免长时间等待

--- a/common/src/taskmanager.rs
+++ b/common/src/taskmanager.rs
@@ -330,23 +330,42 @@ pub struct SubmitSmsLoginResult {
     pub message: String,
     pub cookie: Option<String>,
 }
+/// 运行中抢票任务的快照，供 UI 渲染（无 `Instant`，可直接跨线程 clone）
+#[derive(Clone, Debug)]
+pub struct RunningTaskInfo {
+    pub task_id: String,
+    /// 友好序号，#1 #2 …
+    pub seq: u64,
+    pub uid: i64,
+    pub account_name: String,
+    pub project_name: String,
+    /// 0 定时 1 直接 2 捡漏
+    pub grab_mode: u8,
+    pub status: TaskStatus,
+    /// 查询时即时算出的已运行秒数
+    pub elapsed_secs: u64,
+}
+
 // 更新 TaskManager trait
 pub trait TaskManager: Send + 'static {
     // 创建新的任务管理器
     fn new() -> Self where Self: Sized;
-    
+
     // 提交任务
     fn submit_task(&mut self, request: TaskRequest) -> Result<String, String>;
-    
+
     // 获取可用结果，返回 TaskResult 枚举
     fn get_results(&mut self) -> Vec<TaskResult>;
-    
+
     // 取消任务
     fn cancel_task(&mut self, task_id: &str) -> Result<(), String>;
 
     // 获取任务状态
     fn get_task_status(&self, task_id: &str) -> Option<TaskStatus>;
-     
+
+    // 列出所有正在运行的抢票任务快照
+    fn list_running_tasks(&self) -> Vec<RunningTaskInfo>;
+
      // 关闭任务管理器
     fn shutdown(&mut self);
 }

--- a/frontend/src/app.rs
+++ b/frontend/src/app.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::fs::File;
 use std::io::{Read, Write};
@@ -182,8 +181,6 @@ pub struct Myapp{
 
 pub struct AccountManager{
     pub accounts: Vec<Account>,
-    
-    pub active_tasks: HashMap<String, TicketTask>,
 }
 
 //获取全部订单结构体（便于区分）
@@ -273,7 +270,6 @@ impl Myapp{
              task_manager: Box::new(TaskManagerImpl::new()),
              account_manager: AccountManager {
                  accounts: Config::load_all_accounts(),
-                 active_tasks: HashMap::new(),
              },
              
             push_config : match serde_json::from_value::<PushConfig>(config["push_config"].clone()) {

--- a/frontend/src/app.rs
+++ b/frontend/src/app.rs
@@ -388,19 +388,20 @@ impl Myapp{
         if self.logs.len() > 5000 {
             self.logs.drain(0..2500); // 删除前一半日志
         }
-        // 首先检查是否为错误消息 - 给错误消息更高优先级
-        if message.contains("ERROR:") || message.contains("error:") || message.contains("Error:") {
+        // 横幅触发判定。
+        
+        let is_error = message.contains("] ERROR");
+        
+        let is_success = message.contains("成功") ;
+
+        
+        if is_error {
             self.error_banner_active = true;
             self.error_banner_text = message.to_string();
             self.error_banner_start_time = Some(std::time::Instant::now());
             self.error_banner_opacity = 1.0;
         }
-        // 然后检查是否为成功消息，但使用更严格的条件
-        else if message.contains("info:") || 
-                message.contains("INFO:") || 
-                message.contains("Info:") || 
-                (message.contains("INFO:") && !message.contains("ERROR:")) ||  // 只有包含INFO但不包含ERROR的才算成功
-                message.contains("下单成功") {  
+        else if is_success {
             self.success_banner_active = true;
             self.success_banner_text = message.to_string();
             self.success_banner_start_time = Some(std::time::Instant::now());
@@ -789,6 +790,13 @@ impl Myapp{
 
 impl eframe::App for Myapp{
     fn update(&mut self, ctx:&egui::Context, frame: &mut eframe::Frame){
+        // egui 默认是“响应式”重绘：仅在有输入事件（鼠标/键盘）或显式 request_repaint 时才刷新。
+        // 抢票任务运行在后台独立线程（TaskManagerImpl 的 worker 线程 + tokio），不受 UI 影响，
+        // 即使界面静止也在正常抢票；但若不主动请求重绘，鼠标静止时界面（已运行计时、实时日志、
+        // 任务列表、后台结果处理）会看起来“卡住”。这里请求一个稳定的基线重绘保证界面持续刷新。
+        // 日志列表已虚拟化、任务卡片数量很少，此处低频重绘开销可忽略，不会重新引入卡顿。
+        ctx.request_repaint_after(std::time::Duration::from_millis(100));
+
         //侧栏
         ui::sidebar::render_sidebar(self,ctx);
 

--- a/frontend/src/ui/tabs/monitor.rs
+++ b/frontend/src/ui/tabs/monitor.rs
@@ -1,14 +1,167 @@
 use eframe::egui;
 use crate::app::Myapp;
+use common::taskmanager::TaskStatus;
+
+fn grab_mode_label(mode: u8) -> &'static str {
+    match mode {
+        0 => "定时",
+        1 => "直接",
+        2 => "捡漏",
+        _ => "未知",
+    }
+}
+
+/// 不同抢票模式对应的标签底色
+fn mode_color(mode: u8) -> egui::Color32 {
+    match mode {
+        0 => egui::Color32::from_rgb(64, 150, 238),  // 定时 - 蓝
+        1 => egui::Color32::from_rgb(76, 175, 80),   // 直接 - 绿
+        2 => egui::Color32::from_rgb(255, 145, 77),  // 捡漏 - 橙
+        _ => egui::Color32::from_rgb(150, 150, 160),
+    }
+}
+
+/// 小圆角标签（彩色底 + 白字）
+fn badge(ui: &mut egui::Ui, text: &str, fill: egui::Color32) {
+    egui::Frame::none()
+        .fill(fill)
+        .rounding(7.0)
+        .inner_margin(egui::vec2(7.0, 2.0))
+        .show(ui, |ui| {
+            ui.label(
+                egui::RichText::new(text)
+                    .color(egui::Color32::WHITE)
+                    .size(12.5)
+                    .strong(),
+            );
+        });
+}
 
 pub fn render(app: &mut Myapp, ui: &mut egui::Ui){
     app.show_log_window = true;
+
+    // 配色（卡片为暗色主题上的亮色岛屿，与 account 标签页风格一致）
+    let c_dark = egui::Color32::from_rgb(55, 58, 74);
+    let c_gray = egui::Color32::from_rgb(120, 124, 140);
+    let c_weak = egui::Color32::from_rgb(150, 154, 170);
+    let c_card = egui::Color32::from_rgb(247, 248, 251);
+    let c_border = egui::Color32::from_rgb(228, 230, 240);
+    let c_slate = egui::Color32::from_rgb(99, 108, 130);
+    let c_pink = egui::Color32::from_rgb(251, 114, 153);
+    let c_cancel = egui::Color32::from_rgb(235, 87, 87);
+    let c_cancelling = egui::Color32::from_rgb(245, 166, 35);
+
     if let Some(accounce) = app.announce3.clone() {
         ui.label(accounce);
     } else {
         ui.label("无法连接服务器");
     }
-    
-    ui.separator();
 
+    ui.separator();
+    ui.add_space(4.0);
+
+    // 运行中任务列表（自日志窗口迁移至此监视面板）
+    let running_tasks = app.task_manager.list_running_tasks();
+
+    // 区块标题 + 数量徽标
+    ui.horizontal(|ui| {
+        ui.label(egui::RichText::new("🎫 运行中任务").size(17.0).strong());
+        ui.add_space(6.0);
+        badge(ui, &running_tasks.len().to_string(), c_pink);
+    });
+    ui.add_space(8.0);
+
+    let mut tasks_to_cancel: Vec<String> = Vec::new();
+
+    if running_tasks.is_empty() {
+        // 空状态卡片
+        egui::Frame::none()
+            .fill(c_card)
+            .rounding(10.0)
+            .stroke(egui::Stroke::new(1.0, c_border))
+            .inner_margin(egui::Margin::symmetric(12.0, 18.0))
+            .show(ui, |ui| {
+                ui.vertical_centered(|ui| {
+                    ui.label(egui::RichText::new("当前暂无运行中的抢票任务").size(14.0).color(c_gray));
+                    ui.add_space(3.0);
+                    ui.label(egui::RichText::new("开始抢票后，任务会显示在这里").size(12.0).color(c_weak));
+                });
+            });
+    } else {
+        egui::ScrollArea::vertical()
+            .id_source("running_tasks_scroll")
+            .auto_shrink([false, true])
+            .max_height(320.0)
+            .show(ui, |ui| {
+                for task in &running_tasks {
+                    egui::Frame::none()
+                        .fill(c_card)
+                        .rounding(10.0)
+                        .stroke(egui::Stroke::new(1.0, c_border))
+                        .inner_margin(egui::Margin::symmetric(12.0, 10.0))
+                        .show(ui, |ui| {
+                            // 第一行：序号 + 账号 + 模式标签 ……（右）取消
+                            ui.horizontal(|ui| {
+                                badge(ui, &format!("#{}", task.seq), c_slate);
+                                ui.add_space(6.0);
+                                ui.label(
+                                    egui::RichText::new(&task.account_name)
+                                        .size(16.0)
+                                        .strong()
+                                        .color(c_dark),
+                                );
+                                ui.add_space(6.0);
+                                badge(ui, grab_mode_label(task.grab_mode), mode_color(task.grab_mode));
+
+                                // 右侧操作区
+                                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                                    if let TaskStatus::Failed(msg) = &task.status {
+                                        badge(ui, msg, c_cancelling);
+                                    } else {
+                                        let cancel_btn = egui::Button::new(
+                                                egui::RichText::new("取消").color(egui::Color32::WHITE).size(13.0),
+                                            )
+                                            .fill(c_cancel)
+                                            .rounding(7.0)
+                                            .min_size(egui::vec2(54.0, 24.0));
+                                        if ui.add(cancel_btn).on_hover_text("停止该抢票任务").clicked() {
+                                            tasks_to_cancel.push(task.task_id.clone());
+                                        }
+                                    }
+                                });
+                            });
+
+                            ui.add_space(6.0);
+
+                            // 第二行：项目 + 已运行时长
+                            ui.horizontal(|ui| {
+                                ui.label(egui::RichText::new("项目").size(12.0).color(c_weak));
+                                ui.add_space(4.0);
+                                ui.label(egui::RichText::new(&task.project_name).size(13.0).color(c_gray));
+
+                                ui.add_space(16.0);
+
+                                let mins = task.elapsed_secs / 60;
+                                let secs = task.elapsed_secs % 60;
+                                ui.label(egui::RichText::new("已运行").size(12.0).color(c_weak));
+                                ui.add_space(4.0);
+                                ui.label(
+                                    egui::RichText::new(format!("{:02}:{:02}", mins, secs))
+                                        .size(13.0)
+                                        .strong()
+                                        .color(c_gray),
+                                );
+                            });
+                        });
+                    ui.add_space(8.0);
+                }
+            });
+    }
+    // 借用结束后统一执行取消，避免对 app 的可变借用冲突
+    for task_id in tasks_to_cancel {
+        match app.task_manager.cancel_task(&task_id) {
+            Ok(_) => log::info!("已请求取消任务: {}", task_id),
+            Err(e) => log::error!("取消任务失败: {}", e),
+        }
+    }
 }

--- a/frontend/src/windows/log_windows.rs
+++ b/frontend/src/windows/log_windows.rs
@@ -1,12 +1,31 @@
 
 use eframe::egui;
 use crate::app::Myapp;
+use common::taskmanager::TaskStatus;
+
+fn grab_mode_label(mode: u8) -> &'static str {
+    match mode {
+        0 => "定时",
+        1 => "直接",
+        2 => "捡漏",
+        _ => "未知",
+    }
+}
+
+fn status_label(status: &TaskStatus) -> String {
+    match status {
+        TaskStatus::Pending => "等待中".to_string(),
+        TaskStatus::Running => "运行中".to_string(),
+        TaskStatus::Completed(_) => "已完成".to_string(),
+        TaskStatus::Failed(msg) => msg.clone(),
+    }
+}
 
 pub fn show(app: &mut Myapp, ctx: &egui::Context) {
-    
+
     let mut window_open = app.show_log_window;
     let mut user_close: bool = false;
-    
+
     egui::Window::new("监视面板")
         .open(&mut window_open)
         .default_size([550.0, 400.0])
@@ -17,11 +36,11 @@ pub fn show(app: &mut Myapp, ctx: &egui::Context) {
                 if ui.button("清空日志").clicked() {
                     app.logs.clear();
                 }
-                
+
                 if ui.button("添加测试日志").clicked() {
                     app.add_log("测试日志消息");
                 }
-                
+
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::RIGHT), |ui| {
                     if ui.button("❌").clicked() {
                         user_close = true;
@@ -29,11 +48,67 @@ pub fn show(app: &mut Myapp, ctx: &egui::Context) {
                     }
                 });
             });
-            
+
             ui.separator();
-            
+
+            // 运行中任务列表
+            let running_tasks = app.task_manager.list_running_tasks();
+            ui.label(egui::RichText::new(format!("运行中任务（{}）", running_tasks.len())).strong());
+            let mut tasks_to_cancel: Vec<String> = Vec::new();
+            if running_tasks.is_empty() {
+                ui.label("当前无运行中的抢票任务");
+            } else {
+                egui::ScrollArea::vertical()
+                    .id_source("running_tasks_scroll")
+                    .auto_shrink([false, true])
+                    .max_height(150.0)
+                    .show(ui, |ui| {
+                        egui::Grid::new("running_tasks_grid")
+                            .num_columns(6)
+                            .striped(true)
+                            .spacing([12.0, 4.0])
+                            .show(ui, |ui| {
+                                ui.label(egui::RichText::new("#").strong());
+                                ui.label(egui::RichText::new("账号").strong());
+                                ui.label(egui::RichText::new("项目").strong());
+                                ui.label(egui::RichText::new("模式").strong());
+                                ui.label(egui::RichText::new("已运行").strong());
+                                ui.label(egui::RichText::new("操作").strong());
+                                ui.end_row();
+
+                                for task in &running_tasks {
+                                    ui.label(format!("#{}", task.seq));
+                                    ui.label(&task.account_name);
+                                    ui.label(&task.project_name);
+                                    ui.label(grab_mode_label(task.grab_mode));
+                                    let mins = task.elapsed_secs / 60;
+                                    let secs = task.elapsed_secs % 60;
+                                    ui.label(format!("{:02}:{:02}", mins, secs));
+                                    ui.horizontal(|ui| {
+                                        if matches!(task.status, TaskStatus::Failed(_)) {
+                                            ui.label(status_label(&task.status));
+                                        } else if ui.button("取消").clicked() {
+                                            tasks_to_cancel.push(task.task_id.clone());
+                                        }
+                                    });
+                                    ui.end_row();
+                                }
+                            });
+                    });
+            }
+            // 借用结束后统一执行取消，避免对 app 的可变借用冲突
+            for task_id in tasks_to_cancel {
+                match app.task_manager.cancel_task(&task_id) {
+                    Ok(_) => log::info!("已请求取消任务: {}", task_id),
+                    Err(e) => log::error!("取消任务失败: {}", e),
+                }
+            }
+
+            ui.separator();
+
             // 日志内容区域
             egui::ScrollArea::vertical()
+                .id_source("log_scroll")
                 .auto_shrink([false, false])
                 .stick_to_bottom(true)
                 .max_height(300.0)

--- a/frontend/src/windows/log_windows.rs
+++ b/frontend/src/windows/log_windows.rs
@@ -1,30 +1,11 @@
 
 use eframe::egui;
 use crate::app::Myapp;
-use common::taskmanager::TaskStatus;
-
-fn grab_mode_label(mode: u8) -> &'static str {
-    match mode {
-        0 => "定时",
-        1 => "直接",
-        2 => "捡漏",
-        _ => "未知",
-    }
-}
-
-fn status_label(status: &TaskStatus) -> String {
-    match status {
-        TaskStatus::Pending => "等待中".to_string(),
-        TaskStatus::Running => "运行中".to_string(),
-        TaskStatus::Completed(_) => "已完成".to_string(),
-        TaskStatus::Failed(msg) => msg.clone(),
-    }
-}
 
 pub fn show(app: &mut Myapp, ctx: &egui::Context) {
 
     let mut window_open = app.show_log_window;
-    let mut user_close: bool = false;
+    let mut user_close = false;
 
     egui::Window::new("监视面板")
         .open(&mut window_open)
@@ -43,100 +24,49 @@ pub fn show(app: &mut Myapp, ctx: &egui::Context) {
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::RIGHT), |ui| {
                     if ui.button("❌").clicked() {
+                        // 标记关闭，循环外统一回写，避免与 .open() 的可变借用冲突
                         user_close = true;
-                        app.show_log_window = false;
                     }
                 });
             });
 
             ui.separator();
 
-            // 运行中任务列表
-            let running_tasks = app.task_manager.list_running_tasks();
-            ui.label(egui::RichText::new(format!("运行中任务（{}）", running_tasks.len())).strong());
-            let mut tasks_to_cancel: Vec<String> = Vec::new();
-            if running_tasks.is_empty() {
-                ui.label("当前无运行中的抢票任务");
-            } else {
-                egui::ScrollArea::vertical()
-                    .id_source("running_tasks_scroll")
-                    .auto_shrink([false, true])
-                    .max_height(150.0)
-                    .show(ui, |ui| {
-                        egui::Grid::new("running_tasks_grid")
-                            .num_columns(6)
-                            .striped(true)
-                            .spacing([12.0, 4.0])
-                            .show(ui, |ui| {
-                                ui.label(egui::RichText::new("#").strong());
-                                ui.label(egui::RichText::new("账号").strong());
-                                ui.label(egui::RichText::new("项目").strong());
-                                ui.label(egui::RichText::new("模式").strong());
-                                ui.label(egui::RichText::new("已运行").strong());
-                                ui.label(egui::RichText::new("操作").strong());
-                                ui.end_row();
-
-                                for task in &running_tasks {
-                                    ui.label(format!("#{}", task.seq));
-                                    ui.label(&task.account_name);
-                                    ui.label(&task.project_name);
-                                    ui.label(grab_mode_label(task.grab_mode));
-                                    let mins = task.elapsed_secs / 60;
-                                    let secs = task.elapsed_secs % 60;
-                                    ui.label(format!("{:02}:{:02}", mins, secs));
-                                    ui.horizontal(|ui| {
-                                        if matches!(task.status, TaskStatus::Failed(_)) {
-                                            ui.label(status_label(&task.status));
-                                        } else if ui.button("取消").clicked() {
-                                            tasks_to_cancel.push(task.task_id.clone());
-                                        }
-                                    });
-                                    ui.end_row();
-                                }
-                            });
-                    });
-            }
-            // 借用结束后统一执行取消，避免对 app 的可变借用冲突
-            for task_id in tasks_to_cancel {
-                match app.task_manager.cancel_task(&task_id) {
-                    Ok(_) => log::info!("已请求取消任务: {}", task_id),
-                    Err(e) => log::error!("取消任务失败: {}", e),
-                }
-            }
+            // 当前状态（放在滚动区外，保持常驻可见）
+            ui.label(format!("当前状态: {}",
+                if app.running_status.is_empty() { "未知状态" } else { &app.running_status }));
 
             ui.separator();
 
             // 日志内容区域
-            egui::ScrollArea::vertical()
-                .id_source("log_scroll")
-                .auto_shrink([false, false])
-                .stick_to_bottom(true)
-                .max_height(300.0)
-                .show(ui, |ui| {
-                    // 显示当前状态
-                    ui.label(format!("当前状态: {}", 
-                        if app.running_status.is_empty() { "未知状态" } else { &app.running_status }));
-                    
-                    ui.separator();
-                    
-                    // 显示所有日志
-                    if app.logs.is_empty() {
-                        ui.label("暂无日志记录");
-                        
-                    } else {
-                        for log in &app.logs {
-                            ui.label(log);
-                            ui.separator();
+            // 关键性能修复：原实现每帧为全部 5000 条日志各创建一个 Label + Separator，
+            // 抢票时横幅持续触发 60fps 重绘，导致严重卡顿。改用 show_rows 行虚拟化，
+            // 仅渲染可见行；并去掉逐行 separator（show_rows 要求行高一致）。
+            if app.logs.is_empty() {
+                ui.label("暂无日志记录");
+            } else {
+                let row_height = ui.text_style_height(&egui::TextStyle::Body);
+                let total_rows = app.logs.len();
+                let logs = &app.logs;
+                egui::ScrollArea::both()
+                    .id_source("log_scroll")
+                    .auto_shrink([false, false])
+                    .stick_to_bottom(true)
+                    .max_height(300.0)
+                    .show_rows(ui, row_height, total_rows, |ui, row_range| {
+                        for row in row_range {
+                            // 单行不换行：保证行高一致，长行可横向滚动查看
+                            ui.add(egui::Label::new(logs[row].as_str()).wrap(false));
                         }
-                    }
-                });
-                
+                    });
+            }
+
+            ui.separator();
+
             // 底部状态栏
-            ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
-                ui.label(format!("共 {} 条日志", app.logs.len()));
-            });
+            ui.label(format!("共 {} 条日志", app.logs.len()));
         });
-    
-    // 更新窗口状态
-    app.show_log_window = window_open;
+
+    // 更新窗口状态（标题栏 X 经 window_open 生效；自定义 ❌ 经 user_close 生效）
+    app.show_log_window = window_open && !user_close;
 }

--- a/frontend/src/windows/screen_info.rs
+++ b/frontend/src/windows/screen_info.rs
@@ -150,8 +150,8 @@ pub fn show(app: &mut Myapp, ctx: &egui::Context, uid: i64) {
                                             egui::Button::new(button_text)
                                         ).clicked() {
                                             // 使用正确的类型赋值
-                                            if !ticket.clickable.unwrap_or(false){
-                                                log::error!("请注意！该票种目前不可售！但是会尝试下单，如果该票持续不可售，多次下单不可售票种可能会被b站拉黑")
+                                            if !ticket.clickable.unwrap_or(false) && app.grab_mode == 1 {
+                                                log::error!("请注意！该票种目前不可售！您选择的直接抢票模式会尝试下单，如果该票持续不可售，多次下单不可售票种可能会被b站拉黑")
                                             }
                                             app.selected_screen_id = Some(selected_screen.id.unwrap_or(0) as i64);
                                             app.selected_ticket_id = Some(ticket.id.unwrap_or(0) as i64);


### PR DESCRIPTION
## 关联 issue

Closes #41

## 背景

README 宣称支持同时运行多个抢票任务，但 UI 上无处确认当前有几个任务在跑、各自的配置，容易重复提交 / 配置出错。本 PR 在「监视面板」实现运行任务列表、取消任务，并为每条日志标注所属任务。

## 改动

- **common/taskmanager**：新增面向 UI 的 `RunningTaskInfo` 快照结构体；`TaskManager` trait 新增 `list_running_tasks()`。
- **backend/taskmanager**：
  - 新增共享抢票任务注册表 `grab_registry: Arc<Mutex<HashMap<..>>>` + 序号计数器。
  - worker 在 spawn 抢票协程前登记任务；用 RAII 守卫 `GrabRegistryGuard` 在任务结束时（正常退出 / 取消 / panic unwind）自动从注册表移除，避免僵尸条目。
  - 三种抢票模式（定时 / 直接 / 捡漏）的各循环节点加入 `AtomicBool` 取消检查；倒计时的 15s sleep 拆为 1s 分片，取消约 1 秒内生效。
  - 重写 `cancel_task` 为直接置取消标志；实现 `list_running_tasks`。
  - 修复 `submit_task` 未将生成的 `task_id` 注入 `GrabTicketRequest` 的既有 bug。
- **common/record_log**：用 `tokio::task_local!` 为每个抢票协程绑定 `#序号 账号` 标签，日志输出时自动加前缀（GUI 线程读不到标签，自然无前缀）。
- **frontend/log_windows**：监视面板顶部渲染运行中任务列表（序号 / 账号 / 项目 / 模式 / 已运行时长）及每个任务的取消按钮。
- **frontend/app**：移除从未使用的 `active_tasks` 死代码字段。
