### PR TITLE
fix: 修复 Star History 图表失效问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,10 @@ A: 请确认是否开启了日志记录功能。可在设置中调整日志级�
 <!-- 可以添加许可证信息 -->
 ## Star History
 
-<a href="https://star-history.com/#biliticket/bili_ticket_rush&Date">
+<a href="https://star-history.dera.page/#biliticket/bili_ticket_rush&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=biliticket/bili_ticket_rush&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=biliticket/bili_ticket_rush&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=biliticket/bili_ticket_rush&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=biliticket/bili_ticket_rush&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=biliticket/bili_ticket_rush&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=biliticket/bili_ticket_rush&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
当前 README 中的 Star History 图表因 GitHub stargazer API 限制已无法正常显示。本 PR 将图表切换到新的数据源，恢复 Star History 图表的正常展示。